### PR TITLE
fix: trim data attribute incorrectly set

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,5 +34,4 @@ sh_test(
     size = "small",
     srcs = [":hydrate"],
     args = ["$(location :hydrate)"],
-    data = [":hydrate"],
 )


### PR DESCRIPTION
In my example, I incorrectly set the `data` attribute.  Really not sure why.

Trimmed for completeness, but it wasn't hurting anything